### PR TITLE
cargo fmt + GH workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,46 @@
+permissions:
+  contents: read
+on:
+  push:
+    branches: [main]
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: check
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: format
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: build
+        run: cargo build --release --all-features
+  fmt:
+    runs-on: ubuntu-latest
+    name: format
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: fmt --check
+        run: cargo fmt --check
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: clippy
+        run: cargo clippy --all-targets --all-features
+        env:
+          RUSTFLAGS: "-Dwarnings"
+  doc:
+    runs-on: ubuntu-latest
+    name: doc
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: cargo doc
+        run: cargo doc --no-deps --all-features

--- a/src/main.rs
+++ b/src/main.rs
@@ -955,7 +955,7 @@ fn send_dns_failed(sock: &UdpSocket, req: &Message<[u8]>, code: Rcode, from: &So
 fn dns_thread(
     sock: UdpSocket,
     db_conn: Arc<Mutex<rusqlite::Connection>>,
-    seed_name: &String,
+    seed_name: &str,
     chain: &Network,
 ) {
     #[allow(clippy::single_char_pattern)]
@@ -1041,7 +1041,7 @@ fn dns_thread(
                         continue;
                     }
                     let filter_label = name.first().to_string();
-                    if !filter_label.starts_with("x") || filter_label.starts_with("x0") {
+                    if !filter_label.starts_with('x') || filter_label.starts_with("x0") {
                         send_dns_failed(&sock, req, Rcode::NXDomain, &from);
                         continue;
                     }


### PR DESCRIPTION
If `cargo fmt`-ed code is desirable here, the first commit runs it initially, and the second provides a GH action to check `cargo fmt`, `cargo doc` and `cargo clippy`, which was extracted and modified from https://github.com/jonhoo/faktory-rs

Example failure and pass of the actions [here](https://github.com/willcl-ark/dnsseedrs/actions)