### PR TITLE
nix: add nix module and flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,23 @@
+permissions:
+  contents: read
+on:
+  push:
+    branches: [main]
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: nix
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+      - run: nix flake check
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+      - run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/seeds.txt*
 **/K*.key
 **/K*.private
+/result

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Record set as applicable.
 
 ## Installation
 
+### NixOS
+
+A NixOS module is available for declarative deployment, including multi-instance
+support and systemd hardening. See [nixos/README.md](nixos/README.md) for setup
+instructions.
+
+### Manual
+
 DNSSeedrs is a single self contained binary. Simple compile it with `cargo build --release` and
 the resulting `dnsseedrs` binary can be used as a simple server binary.
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  sqlite,
+  darwin,
+  stdenv,
+}:
+
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+  src = lib.cleanSource ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs =
+    [ sqlite ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  meta = {
+    description = "Bitcoin DNS seeder";
+    mainProgram = "dnsseedrs";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770770419,
+        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "dnsseedrs - Bitcoin DNS seeder";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        dnsseedrs = pkgs.callPackage ./default.nix { };
+      in
+      {
+        packages.default = dnsseedrs;
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ dnsseedrs ];
+          packages = [ pkgs.rust-analyzer ];
+        };
+      }
+    )
+    // {
+      nixosModules.default = import ./nixos/module.nix;
+      overlays.default = final: _prev: {
+        dnsseedrs = final.callPackage ./default.nix { };
+      };
+    };
+}

--- a/nixos/README.md
+++ b/nixos/README.md
@@ -1,0 +1,240 @@
+# NixOS Module for dnsseedrs
+
+## Quick Start
+
+### With Flakes
+
+Add dnsseedrs to your flake inputs and import the module:
+
+```nix
+{
+  inputs.dnsseedrs.url = "github:achow101/dnsseedrs";
+
+  outputs = { nixpkgs, dnsseedrs, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        dnsseedrs.nixosModules.default
+        {
+          nixpkgs.overlays = [ dnsseedrs.overlays.default ];
+          services.dnsseedrs.mainnet = {
+            enable = true;
+            chain = "main";
+            seedDomain = "seed.example.com";
+            serverName = "ns.example.com";
+            soaRname = "admin.example.com";
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+### Without Flakes
+
+```nix
+let
+  dnsseedrs = builtins.fetchGit {
+    url = "https://github.com/achow101/dnsseedrs";
+    ref = "main";
+  };
+in
+{
+  imports = [ "${dnsseedrs}/nixos/module.nix" ];
+  nixpkgs.overlays = [
+    (final: _prev: { dnsseedrs = final.callPackage "${dnsseedrs}/default.nix" { }; })
+  ];
+
+  services.dnsseedrs.mainnet = {
+    enable = true;
+    chain = "main";
+    seedDomain = "seed.example.com";
+    serverName = "ns.example.com";
+    soaRname = "admin.example.com";
+  };
+}
+```
+
+## Multiple Instances
+
+Each key under `services.dnsseedrs` creates an independent instance with its own
+systemd service (`dnsseedrs-<name>`) and state directory (`/var/lib/dnsseedrs/<name>`).
+
+See `example-configuration.nix` for a mainnet + signet setup.
+
+## Module Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enable` | bool | `false` | Enable this instance |
+| `package` | package | `pkgs.dnsseedrs` | Package to use |
+| `chain` | enum | *(required)* | `"main"`, `"test"`, `"testnet4"`, or `"signet"` |
+| `seedDomain` | string | *(required)* | Domain to serve DNS results for |
+| `serverName` | string | *(required)* | This server's domain (NS target) |
+| `soaRname` | string | *(required)* | SOA rname field value |
+| `seedNodes` | list of string | `[]` | Initial seed node addresses |
+| `dbFile` | string | `"sqlite.db"` | SQLite database filename |
+| `dumpFile` | string | `"seeds.txt"` | Dump file for good addresses |
+| `noIpv4` | bool | `false` | Disable IPv4 crawling |
+| `noIpv6` | bool | `false` | Disable IPv6 crawling |
+| `cjdnsReachable` | bool | `false` | Enable CJDNS reachability |
+| `onionProxy` | string or null | `null` | Tor SOCKS5 proxy address |
+| `i2pProxy` | string or null | `null` | I2P SOCKS5 proxy address |
+| `threads` | positive int | `24` | Crawler thread count |
+| `bind` | list of string | `[]` | DNS bind addresses (e.g. `udp://0.0.0.0:53`) |
+| `dnssecKeys` | path or null | `null` | DNSSEC key directory |
+| `asmap` | path or null | `null` | ASMap file path |
+| `extraArgs` | list of string | `[]` | Additional CLI arguments |
+
+## CoreDNS Forwarding
+
+Bind dnsseedrs to a non-privileged port and use CoreDNS to forward queries to it.
+The catch-all zone at the bottom is important — without it, CoreDNS acts as an open
+DNS resolver and you will receive abuse complaints.
+
+```nix
+{ ... }:
+{
+  services.dnsseedrs.mainnet = {
+    enable = true;
+    chain = "main";
+    seedDomain = "seed.example.com";
+    serverName = "ns.example.com";
+    soaRname = "admin.example.com";
+    bind = [
+      "udp://127.0.0.1:5353"
+      "tcp://127.0.0.1:5353"
+    ];
+  };
+
+  services.coredns = {
+    enable = true;
+    config = ''
+      seed.example.com:53 {
+        bind 0.0.0.0 ::
+        forward . 127.0.0.1:5353
+        any
+        log
+      }
+
+      .:53 {
+        bind 0.0.0.0 ::
+        any
+        template ANY ANY {
+          rcode REFUSED
+        }
+        log
+      }
+    '';
+  };
+}
+```
+
+## DNSSEC
+
+dnsseedrs can sign DNS responses when pointed at a directory containing keys
+produced by `dnssec-keygen`. Since the public key must be registered as a DS
+record with your domain registrar, keys should be generated offline and deployed
+as secrets.
+
+### 1. Generate keys
+
+Generate a ZSK and KSK for your seed domain:
+
+```bash
+dnssec-keygen -a ECDSAP256SHA256 -n ZONE seed.example.com
+dnssec-keygen -a ECDSAP256SHA256 -n ZONE -f KSK seed.example.com
+```
+
+This produces 4 files (the tags `XXXXX`/`YYYYY` will vary):
+- `Kseed.example.com.+013+XXXXX.key` / `.private` (ZSK)
+- `Kseed.example.com.+013+YYYYY.key` / `.private` (KSK)
+
+### 2. Create the DS record for your registrar
+
+```bash
+dnssec-dsfromkey Kseed.example.com.+013+YYYYY.key
+```
+
+Submit the output as a DS record with your domain registrar.
+
+### 3. Encrypt with sops
+
+In your deployment repo (where `.sops.yaml` is configured), encrypt each key
+file as binary:
+
+```bash
+mkdir -p secrets
+for f in Kseed.example.com.+013+*.key Kseed.example.com.+013+*.private; do
+  sops encrypt --input-type binary --output-type binary "$f" > "secrets/$f"
+done
+```
+
+### 4. Deploy with sops-nix
+
+```nix
+{ config, ... }:
+let
+  keyDir = "/run/secrets/dnsseedrs-keys";
+in
+{
+  sops.secrets."dnsseedrs-zsk-key" = {
+    sopsFile = ./secrets/Kseed.example.com.+013+XXXXX.key;
+    format = "binary";
+    path = "${keyDir}/Kseed.example.com.+013+XXXXX.key";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-zsk-private" = {
+    sopsFile = ./secrets/Kseed.example.com.+013+XXXXX.private;
+    format = "binary";
+    path = "${keyDir}/Kseed.example.com.+013+XXXXX.private";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-ksk-key" = {
+    sopsFile = ./secrets/Kseed.example.com.+013+YYYYY.key;
+    format = "binary";
+    path = "${keyDir}/Kseed.example.com.+013+YYYYY.key";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-ksk-private" = {
+    sopsFile = ./secrets/Kseed.example.com.+013+YYYYY.private;
+    format = "binary";
+    path = "${keyDir}/Kseed.example.com.+013+YYYYY.private";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+
+  services.dnsseedrs.mainnet = {
+    enable = true;
+    chain = "main";
+    seedDomain = "seed.example.com";
+    serverName = "ns.example.com";
+    soaRname = "admin.example.com";
+    dnssecKeys = keyDir;
+  };
+
+  systemd.services.dnsseedrs-mainnet = {
+    after = [ "sops-install-secrets.service" ];
+    wants = [ "sops-install-secrets.service" ];
+  };
+}
+```
+
+Replace `XXXXX` (ZSK tag) and `YYYYY` (KSK tag) with the actual key tags
+from step 1.
+
+## Service Management
+
+```bash
+# Status
+systemctl status dnsseedrs-mainnet
+
+# Logs
+journalctl -u dnsseedrs-mainnet -f
+
+# Restart
+systemctl restart dnsseedrs-mainnet
+```

--- a/nixos/example-configuration.nix
+++ b/nixos/example-configuration.nix
@@ -1,0 +1,100 @@
+{ config, ... }:
+let
+  domain = "seed.example.com";
+  keyDir = "/run/secrets/dnsseedrs-keys";
+in
+{
+  services.dnsseedrs = {
+    mainnet = {
+      enable = true;
+      chain = "main";
+      seedDomain = domain;
+      serverName = "ns.example.com";
+      soaRname = "admin.example.com";
+      seedNodes = [ "1.2.3.4:8333" ];
+      threads = 32;
+      dnssecKeys = keyDir;
+      bind = [
+        "udp://127.0.0.1:5353"
+        "tcp://127.0.0.1:5353"
+      ];
+    };
+
+    signet = {
+      enable = true;
+      chain = "signet";
+      seedDomain = "signet-seed.example.com";
+      serverName = "ns.example.com";
+      soaRname = "admin.example.com";
+      bind = [
+        "udp://127.0.0.1:5354"
+        "tcp://127.0.0.1:5354"
+      ];
+    };
+  };
+
+  # Deploy DNSSEC keys with sops-nix (replace XXXXX/YYYYY with actual key tags)
+  sops.secrets."dnsseedrs-zsk-key" = {
+    sopsFile = ./secrets + "/K${domain}.+013+XXXXX.key";
+    format = "binary";
+    path = "${keyDir}/K${domain}.+013+XXXXX.key";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-zsk-private" = {
+    sopsFile = ./secrets + "/K${domain}.+013+XXXXX.private";
+    format = "binary";
+    path = "${keyDir}/K${domain}.+013+XXXXX.private";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-ksk-key" = {
+    sopsFile = ./secrets + "/K${domain}.+013+YYYYY.key";
+    format = "binary";
+    path = "${keyDir}/K${domain}.+013+YYYYY.key";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+  sops.secrets."dnsseedrs-ksk-private" = {
+    sopsFile = ./secrets + "/K${domain}.+013+YYYYY.private";
+    format = "binary";
+    path = "${keyDir}/K${domain}.+013+YYYYY.private";
+    owner = "dnsseedrs";
+    group = "dnsseedrs";
+  };
+
+  systemd.services.dnsseedrs-mainnet = {
+    after = [ "sops-install-secrets.service" ];
+    wants = [ "sops-install-secrets.service" ];
+  };
+
+  # CoreDNS forwards seed domain queries to dnsseedrs.
+  # The catch-all zone refuses everything else to avoid being an open resolver.
+  services.coredns = {
+    enable = true;
+    config = ''
+      ${domain}:53 {
+        bind 0.0.0.0 ::
+        forward . 127.0.0.1:5353
+        any
+        log
+      }
+
+      signet-seed.example.com:53 {
+        bind 0.0.0.0 ::
+        forward . 127.0.0.1:5354
+        any
+        log
+      }
+
+      .:53 {
+        bind 0.0.0.0 ::
+        any
+        template ANY ANY {
+          rcode REFUSED
+        }
+        log
+      }
+    '';
+  };
+}

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -1,0 +1,201 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.dnsseedrs;
+  enabledInstances = lib.filterAttrs (_: icfg: icfg.enable) cfg;
+in
+{
+  options.services.dnsseedrs = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "dnsseedrs DNS seeder instance";
+
+          package = lib.mkPackageOption pkgs "dnsseedrs" { };
+
+          chain = lib.mkOption {
+            type = lib.types.enum [
+              "main"
+              "test"
+              "testnet4"
+              "signet"
+            ];
+            description = "Bitcoin network to connect to.";
+          };
+
+          seedDomain = lib.mkOption {
+            type = lib.types.str;
+            description = "Domain name for which this server returns results.";
+          };
+
+          serverName = lib.mkOption {
+            type = lib.types.str;
+            description = "Domain name of this server (NS record target).";
+          };
+
+          soaRname = lib.mkOption {
+            type = lib.types.str;
+            description = "String for the rname field of the SOA record.";
+          };
+
+          seedNodes = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "Initial seed nodes to connect to.";
+          };
+
+          dbFile = lib.mkOption {
+            type = lib.types.str;
+            default = "sqlite.db";
+            description = "SQLite database filename (relative to state directory).";
+          };
+
+          dumpFile = lib.mkOption {
+            type = lib.types.str;
+            default = "seeds.txt";
+            description = "Dump file for known good addresses.";
+          };
+
+          noIpv4 = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Disable IPv4 address crawling.";
+          };
+
+          noIpv6 = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Disable IPv6 address crawling.";
+          };
+
+          cjdnsReachable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable CJDNS reachability.";
+          };
+
+          onionProxy = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "Tor SOCKS5 proxy address (e.g. 127.0.0.1:9050).";
+          };
+
+          i2pProxy = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "I2P SOCKS5 proxy address (e.g. 127.0.0.1:4447).";
+          };
+
+          threads = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 24;
+            description = "Number of crawler threads.";
+          };
+
+          bind = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "Addresses to bind for DNS (e.g. udp://0.0.0.0:53). Empty uses CLI defaults.";
+          };
+
+          dnssecKeys = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = "Path to directory containing DNSSEC keys from dnssec-keygen.";
+          };
+
+          asmap = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = "Path to an asmap file for AS-aware bucketing.";
+          };
+
+          extraArgs = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "Additional command-line arguments.";
+          };
+        };
+      }
+    );
+    default = { };
+    description = "dnsseedrs DNS seeder instances.";
+  };
+
+  config = lib.mkIf (enabledInstances != { }) {
+    users.users.dnsseedrs = {
+      isSystemUser = true;
+      group = "dnsseedrs";
+    };
+    users.groups.dnsseedrs = { };
+
+    systemd.services = lib.mapAttrs' (
+      name: icfg:
+      lib.nameValuePair "dnsseedrs-${name}" {
+        description = "dnsseedrs DNS seeder (${name})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+
+        serviceConfig =
+          let
+            args =
+              lib.cli.toCommandLineGNU { } (
+                lib.filterAttrs (_: v: v != null) {
+                  chain = icfg.chain;
+                  seednode = icfg.seedNodes;
+                  db-file = icfg.dbFile;
+                  dump-file = icfg.dumpFile;
+                  no-ipv4 = icfg.noIpv4;
+                  no-ipv6 = icfg.noIpv6;
+                  cjdns-reachable = icfg.cjdnsReachable;
+                  onion-proxy = icfg.onionProxy;
+                  i2p-proxy = icfg.i2pProxy;
+                  threads = icfg.threads;
+                  bind = icfg.bind;
+                  dnssec-keys = icfg.dnssecKeys;
+                  asmap = icfg.asmap;
+                }
+              )
+              ++ icfg.extraArgs
+              ++ [
+                icfg.seedDomain
+                icfg.serverName
+                icfg.soaRname
+              ];
+          in
+          {
+            ExecStart = "${lib.getExe icfg.package} ${lib.escapeShellArgs args}";
+            User = "dnsseedrs";
+            Group = "dnsseedrs";
+            StateDirectory = "dnsseedrs/${name}";
+            WorkingDirectory = "/var/lib/dnsseedrs/${name}";
+
+            Restart = "always";
+            RestartSec = "10s";
+
+            AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+            CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+            NoNewPrivileges = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            PrivateTmp = true;
+            PrivateDevices = true;
+            ProtectKernelTunables = true;
+            ProtectKernelModules = true;
+            ProtectControlGroups = true;
+            RestrictSUIDSGID = true;
+            RestrictNamespaces = true;
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            RestrictRealtime = true;
+          };
+      }
+    ) enabledInstances;
+  };
+}


### PR DESCRIPTION
Adds a Nix module (`nixos/module.nix`) for declarative deployment, supporting multiple independent instances, all CLI options, DNSSEC key paths, and some sensible-default systemd hardening (restricted capabilities, `ProtectSystem=strict`, etc.).

A flake makes flake-based deployments easier with its export.

Include documentation covering quick-start (flake and non-flake), module options, CoreDNS forwarding setup, and DNSSEC key management with sops-nix. (optional, the example configuration for example could be dropped)

Currently one has to to package dnsseedrs themselves and write their own systemd units.
This gives them a turnkey module they can drop into their configuration with a few lines of Nix.

The CI job is only to try and catch Nix build regressions before they reach main.